### PR TITLE
Remove the hardcoded reference to `us-east-1` region

### DIFF
--- a/registry/s3registry.go
+++ b/registry/s3registry.go
@@ -97,8 +97,7 @@ func (r *S3Registry) getModules(namespace, name, provider string) (modules []mod
 
 func (r *S3Registry) getSession() *session.Session {
 	config := &aws.Config{
-		S3ForcePathStyle: aws.Bool(true),
-		Region:           aws.String("us-east-1"),
+		S3ForcePathStyle: aws.Bool(true)
 	}
 	if r.endpoint != "" {
 		if !strings.HasPrefix(r.endpoint, "https") {


### PR DESCRIPTION
# Description

Remove the hardcoded reference to `us-east-1` region

we don't have to hardcode it. Go can read this from the env var `AWS_REGION`.